### PR TITLE
chore: set create_secret to true by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ export default class SyncSecretPlugin {
       ejson_key: null,
       ssm_prefix: null,
       exclude: '^_',
-      create_secret: false,
+      create_secret: true,
       show_values: false,
       delete_secret: false,
       dry: false,


### PR DESCRIPTION
Se establece en true el campo `create_secret` por defecto para no tener errores al crear nuevos servicios sin el campo `create_secret: true` en serverless.yml.
Al crear un nuevo service, si el secret no existe se crea y luego se sincronizan los secrets (ya no laza error `Secrets Manager can't find the specified secret.`).