### PR TITLE
fix: resolve boolean coercion for env var values in config parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,9 @@ export default class SyncSecretPlugin {
         logger.logInfo(desc);
       }
 
-      if (!dry) {
+      if (dry) {
+        logger.logInfo('Dry mode enabled, skipping secrets sync.');
+      } else {
         await changeSet.apply();
         logger.logInfo('Secrets synced successfully!');
       }
@@ -113,8 +115,9 @@ export default class SyncSecretPlugin {
       const boolKeys = ['create_secret', 'delete_secret', 'show_values', 'dry'];
       boolKeys.forEach((key) => {
         if (key in service.custom.syncSecrets) {
-          logger.logInfo(`${key}: ${service.custom.syncSecrets[key]}`);
-          config[key] = Boolean(service.custom.syncSecrets[key]);
+          const val = service.custom.syncSecrets[key];
+          logger.logInfo(`${key}: ${val}`);
+          config[key] = val === true || String(val).toLowerCase() === 'true';
         }
       });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-plugin-sync-secrets",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-plugin-sync-secrets",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",


### PR DESCRIPTION
Boolean(val) devuelve true para cualquier string no vacío (incluso "false"). Ahora se compara explícitamente con true o con el string "true", lo que maneja correctamente los valores que vienen de variables de entorno.